### PR TITLE
Mark transaction as open when started async

### DIFF
--- a/src/php_pqconn.c
+++ b/src/php_pqconn.c
@@ -1736,6 +1736,7 @@ static PHP_METHOD(pqconn, startTransactionAsync) {
 
 			php_pq_object_addref(obj TSRMLS_CC);
 			txn->conn = obj;
+			txn->open = 1;
 			txn->isolation = isolation;
 			txn->readonly = readonly;
 			txn->deferrable = deferrable;


### PR DESCRIPTION
`txn->open` is not set to `1` on init and there's no handler anywhere to set it on success. In [`Transaction::__construct()`](https://github.com/php/pecl-database-pq/blob/master/src/php_pqtxn.c#L259) it's always set regardless of sync/async.

As handling results of async ops is generally left to the user, I think that simply setting the flag consistently with `Transaction::__construct()` is the right answer here.
